### PR TITLE
bugfix using find without replace

### DIFF
--- a/system/expressionengine/third_party/streeng/pi.streeng.php
+++ b/system/expressionengine/third_party/streeng/pi.streeng.php
@@ -35,10 +35,6 @@ class Streeng {
 			$replace = ee()->TMPL->fetch_param('replace');
 			$insensitive = ee()->TMPL->fetch_param('insensitive');
 
-			$explode = ee()->TMPL->fetch_param('explode', '|');
-
-			$find = explode($explode, $find);
-
 			if ($replace !== false) {
 				// Options
 				$flags = ee()->TMPL->fetch_param('flags');
@@ -58,6 +54,10 @@ class Streeng {
 					'QUOTE'   => '"',
 					'SPACE'   => ' '
 				);
+
+				$explode = ee()->TMPL->fetch_param('explode', '|');
+
+				$find = explode($explode, $find);
 
 				$replace = explode($explode, $replace);
 


### PR DESCRIPTION
using find without a replace parameter caused an array to be passed to stripos throwing a php error.